### PR TITLE
Fix link for whitelist 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ We are calling the space DeSec, the first of its kind decentralized security and
 [Sign up for early access](https://www.interlock.network/)
 
 **Interested in getting whitelist?**
-![Whitelist Info](bit.ly/INTRwhitelist)
+
+[Whitelist Info](https://bit.ly/INTRwhitelist)
 
 **Want to join our team?**
 


### PR DESCRIPTION
GH Readme does not render the links if we dont add `https://`